### PR TITLE
Add blockr

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,11 @@
-exports.SERVICES = ['21.co', 'blockcypher', 'bitpay', 'breadwallet', 'btc.com']
+exports.SERVICES = [
+  '21.co',
+  'blockcypher',
+  'bitpay',
+  'blockr',
+  'breadwallet',
+  'btc.com'
+]
 
 const endpoints = {}
 exports.SERVICES.forEach(service => {

--- a/services/blockr.js
+++ b/services/blockr.js
@@ -1,0 +1,5 @@
+exports.fetchFee = function () {
+  return fetch('http://btc.blockr.io/api/v1/block/info/last')
+  .then(res => res.json())
+  .then(json => (json.data.fee * 100000000) / json.data.size)
+}


### PR DESCRIPTION
Closes #2 

Had to use http://btc.blockr.io/api/v1/block/info/last instead of http://btc.blockr.io/api/v1/coin/info, since `coin/info` only gives the number of transactions; not their size in bytes.