### PR TITLE
Rename 21 co

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const endpoints = {
-  '21.co': require('./services/21.co'),
+  'earn': require('./services/earn'),
   'blockcypher': require('./services/blockcypher'),
   'bitpay': require('./services/bitpay'),
   'btc.com': require('./services/btc.com')

--- a/services/earn.js
+++ b/services/earn.js
@@ -1,5 +1,5 @@
 exports.fetchFee = function () {
-  return fetch('https://bitcoinfees.21.co/api/v1/fees/recommended')
+  return fetch('https://bitcoinfees.earn.com/api/v1/fees/recommended')
   .then(res => res.json())
   .then(json => json.fastestFee)
 }


### PR DESCRIPTION
Version bump to 2.0.0 because this breaks old versions depending on the `21.co` named service.